### PR TITLE
resolved error by checking if object is null before calling getter on it

### DIFF
--- a/healthy_app/lib/screens/home/userSettings_list.dart
+++ b/healthy_app/lib/screens/home/userSettings_list.dart
@@ -14,9 +14,10 @@ class _UserSettingsListState extends State<UserSettingsList> {
     final userSettings = Provider.of<QuerySnapshot>(context);
     //print(userSettings.documents);
     //if(userSettings == null) return CircularProgressIndicator();
-
-    for(var doc in userSettings.documents){
-      print(doc.data);
+    if(userSettings != null){
+      for(var doc in userSettings.documents){
+        print(doc.data);
+      }
     }
     return Container();
   }


### PR DESCRIPTION
Resolved issue with error displaying on screen saying that the getter 'documents' was being called on null. Did this by checking if the object is null before calling the getter 'documents' on it. However, it is still unclear why the object is null so this should be explored in future.