### PR TITLE
Fix calendar so pages refresh when new date selected

### DIFF
--- a/healthy_app/lib/main.dart
+++ b/healthy_app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:healthy_app/screens/home/home.dart';
 import 'package:healthy_app/screens/wrapper.dart';
 import 'package:healthy_app/services/auth.dart';
 import 'package:healthy_app/models/user.dart';
@@ -14,6 +15,10 @@ class myApp extends StatelessWidget {
       value: AuthService().user,
       child: MaterialApp(
           debugShowCheckedModeBanner: false,
+           initialRoute: '/',
+           routes: {
+            '/second': (context) => Home(),
+           },
            home: Wrapper(),
       ),
     );

--- a/healthy_app/lib/main.dart
+++ b/healthy_app/lib/main.dart
@@ -13,22 +13,6 @@ void main() {
   runApp(myApp());
 }
 class myApp extends StatelessWidget {
-  Route<dynamic> _getRoute(RouteSettings settings) {
-    if (settings.name == '/second') {
-      var date = settings.arguments.toString();
-      globals.selectedDate = date;
-      return _buildRoute(settings, new Home());
-    }
-    return null;
-  }
-
-  MaterialPageRoute _buildRoute(RouteSettings settings, Widget builder) {
-    return new MaterialPageRoute(
-      settings: settings,
-      builder: (ctx) => builder,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return StreamProvider<User>.value(
@@ -38,27 +22,6 @@ class myApp extends StatelessWidget {
            initialRoute: '/',
            routes: {
             '/second': (context) => Home(),
-           },
-           onGenerateRoute: (settings) {
-            print("settings name = " + settings.name.toString());
-            final Arguments arg = settings.arguments as Arguments;
-            bool argReturned = false;
-            if(arg != null) {
-              print("arg = " + settings.arguments.toString());
-              argReturned = true;
-            }
-            print("arg be null");
-            return argReturned ? MaterialPageRoute(
-              builder: (context) {
-                return Home(
-                  date: arg.date.toString(),
-                );
-              },
-            ) : MaterialPageRoute(
-              builder: (context) {
-                return Home();
-              },
-            );
            },
            home: Wrapper(),
       ),

--- a/healthy_app/lib/main.dart
+++ b/healthy_app/lib/main.dart
@@ -1,14 +1,34 @@
+import 'dart:core';
+
 import 'package:flutter/material.dart';
+import 'package:healthy_app/models/arguments.dart';
 import 'package:healthy_app/screens/home/home.dart';
 import 'package:healthy_app/screens/wrapper.dart';
 import 'package:healthy_app/services/auth.dart';
 import 'package:healthy_app/models/user.dart';
 import 'package:provider/provider.dart';
+import 'package:healthy_app/shared/globals.dart' as globals;
 
 void main() {
   runApp(myApp());
 }
 class myApp extends StatelessWidget {
+  Route<dynamic> _getRoute(RouteSettings settings) {
+    if (settings.name == '/second') {
+      var date = settings.arguments.toString();
+      globals.selectedDate = date;
+      return _buildRoute(settings, new Home());
+    }
+    return null;
+  }
+
+  MaterialPageRoute _buildRoute(RouteSettings settings, Widget builder) {
+    return new MaterialPageRoute(
+      settings: settings,
+      builder: (ctx) => builder,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return StreamProvider<User>.value(
@@ -18,6 +38,27 @@ class myApp extends StatelessWidget {
            initialRoute: '/',
            routes: {
             '/second': (context) => Home(),
+           },
+           onGenerateRoute: (settings) {
+            print("settings name = " + settings.name.toString());
+            final Arguments arg = settings.arguments as Arguments;
+            bool argReturned = false;
+            if(arg != null) {
+              print("arg = " + settings.arguments.toString());
+              argReturned = true;
+            }
+            print("arg be null");
+            return argReturned ? MaterialPageRoute(
+              builder: (context) {
+                return Home(
+                  date: arg.date.toString(),
+                );
+              },
+            ) : MaterialPageRoute(
+              builder: (context) {
+                return Home();
+              },
+            );
            },
            home: Wrapper(),
       ),

--- a/healthy_app/lib/models/arguments.dart
+++ b/healthy_app/lib/models/arguments.dart
@@ -1,0 +1,4 @@
+class Arguments {
+  final String date;
+  Arguments({ this.date });
+}

--- a/healthy_app/lib/screens/calendar.dart
+++ b/healthy_app/lib/screens/calendar.dart
@@ -19,24 +19,67 @@ class _CalendarViewState extends State<CalendarView> {
 
   void initState() {
     super.initState();
+    selectedDay = getCurrentDate();
     //_controller = CalendarController();
   }
 
-  //EventList<Event> _markedDateMap = new EventList<Event>();
+  showAlertDialog(BuildContext context) {
+    // set up the buttons
+    Widget cancelButton = FlatButton(
+      child: Text("Cancel"),
+      onPressed:  () {
+        Navigator.pop(context);
+      },
+    );
+    Widget continueButton = FlatButton(
+      child: Text("Continue"),
+      onPressed:  () {
+        Navigator.pushNamedAndRemoveUntil(context,
+            "/second",
+              (r) => false,
+              arguments: {
+              "date": selectedDay});
+      },
+    );
+
+    // set up the AlertDialog
+    AlertDialog alert = AlertDialog(
+      title: Text("AlertDialog"),
+      content: Text("Would you like to view data you entered on ${selectedDay}?"),
+      actions: [
+        cancelButton,
+        continueButton,
+      ],
+    );
+
+    // show the dialog
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alert;
+      },
+    );
+  }
+
+  String getCurrentDate(){
+    var date = new DateTime.now().toString();
+    var dateParse = DateTime.parse(date);
+    var formattedDate = "${dateParse.day}/${dateParse.month}/${dateParse.year}";
+    return formattedDate;
+  }
 
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
-        // appBar: new AppBar(
-        //   title: new Text("Calendar"),
-        // ),
-
+        appBar: new AppBar(
+          title: new Text("Calendar"),
+        ),
         body: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
-              Padding(padding: EdgeInsets.only(top: 30.0)),
+              //Padding(padding: EdgeInsets.only(top: 30.0)),
               Container(
                 child: TableCalendar(
                   calendarController: _controller,
@@ -60,9 +103,10 @@ class _CalendarViewState extends State<CalendarView> {
                   padding: const EdgeInsets.all(10.0),
                   child: ElevatedButton(
                     onPressed: (){
-                      Navigator.pop(context, selectedDay);
+                      showAlertDialog(context);
+                     // Navigator.pop(context, selectedDay);
                     },
-                    child: Text("Go back"),
+                    child: Text("Select date"),
                   ),
                 ),
               ),

--- a/healthy_app/lib/screens/calendar.dart
+++ b/healthy_app/lib/screens/calendar.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:healthy_app/models/arguments.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:healthy_app/screens/home/home.dart' as HomePage;
+import 'package:healthy_app/shared/globals.dart' as globals;
 
 class CalendarView extends StatefulWidget {
 
@@ -34,12 +36,19 @@ class _CalendarViewState extends State<CalendarView> {
     Widget continueButton = FlatButton(
       child: Text("Continue"),
       onPressed:  () {
+        setState(() {
+          globals.selectedDate = selectedDay;
+          print("globals selected day = " + globals.selectedDate);
+          globals.newDateSelected = true;
+        });
         Navigator.pushNamedAndRemoveUntil(context,
             "/second",
               (r) => false,
               arguments: {
-              "date": selectedDay});
-      },
+              'date': selectedDay
+              });
+        }
+                //Arguments(date: selectedDay)});
     );
 
     // set up the AlertDialog

--- a/healthy_app/lib/screens/calendar.dart
+++ b/healthy_app/lib/screens/calendar.dart
@@ -38,17 +38,13 @@ class _CalendarViewState extends State<CalendarView> {
       onPressed:  () {
         setState(() {
           globals.selectedDate = selectedDay;
-          print("globals selected day = " + globals.selectedDate);
           globals.newDateSelected = true;
         });
         Navigator.pushNamedAndRemoveUntil(context,
             "/second",
               (r) => false,
-              arguments: {
-              'date': selectedDay
-              });
+              );
         }
-                //Arguments(date: selectedDay)});
     );
 
     // set up the AlertDialog

--- a/healthy_app/lib/screens/home/home.dart
+++ b/healthy_app/lib/screens/home/home.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:healthy_app/models/arguments.dart';
 import 'package:healthy_app/screens/home/settings_list.dart';
 import 'package:healthy_app/screens/settings_page.dart';
 import 'package:healthy_app/services/auth.dart';
@@ -16,6 +17,8 @@ import '../progress.dart';
 import 'package:healthy_app/shared/globals.dart' as globals;
 // ignore: must_be_immutable
 class Home extends StatefulWidget {
+  String date;
+  Home({ this.date});
 
   @override
   _HomeState createState() => _HomeState();
@@ -36,6 +39,8 @@ class _HomeState extends State<Home> {
   void initState() {
     super.initState();
     getUid();
+    print("initState date = " + widget.date.toString());
+    newDate = globals.newDateSelected;
   }
 
   Future<String> getUid() async {
@@ -112,6 +117,11 @@ class _HomeState extends State<Home> {
             age = 0.0;
             weight = 0.0;
           }
+          // final Arguments args = ModalRoute.of(context).settings.arguments;
+         // final Arguments arg = ModalRoute.of(context).settings.arguments as Arguments;
+          //selectedDate = args.date;
+          //final CompactLinkedHashSet<Arguments> arguments = ModalRoute.of(context).settings.arguments as _CompactLinkedHashSet;
+          //if (arguments != null) print(arguments['date']);
           return Scaffold(
             appBar: AppBar(
               leading: GestureDetector(
@@ -124,7 +134,7 @@ class _HomeState extends State<Home> {
                   Icons.calendar_today_outlined,
                 ),
               ),
-              title: newDate ? new Text(selectedDate) : new Text(getCurrentDate()),
+              title: newDate ? new Text(globals.selectedDate) : new Text(getCurrentDate()),
               centerTitle: true,
               actions: <Widget>[
                 PopupMenuButton<String>(


### PR DESCRIPTION
- added back button to calendar so user can navigate backwards without selecting date
- added button to select new date which brings up alert dialog asking user to confirm their action
- if user confirms, globals.selectedDate is updated, route stack is cleared and home() is rendered with new dare