### PR TITLE
Fix time string in medication tracker so a leading zero is displayed when 'minutes' is just one digit

### DIFF
--- a/healthy_app/lib/services/database.dart
+++ b/healthy_app/lib/services/database.dart
@@ -590,6 +590,10 @@ class DatabaseService {
   String getCurrentTime() {
     var time = new DateTime.now().toString();
     var timeParse = DateTime.parse(time);
+    String minute = timeParse.minute.toString();
+    if (timeParse.minute < 10){
+      minute = "0${minute}";
+    }
     var formattedTime = "${timeParse.hour}:${timeParse.minute}";
     return formattedTime;
   }

--- a/healthy_app/lib/services/database.dart
+++ b/healthy_app/lib/services/database.dart
@@ -594,7 +594,7 @@ class DatabaseService {
     if (timeParse.minute < 10){
       minute = "0${minute}";
     }
-    var formattedTime = "${timeParse.hour}:${timeParse.minute}";
+    var formattedTime = "${timeParse.hour}:${minute}";
     return formattedTime;
   }
 


### PR DESCRIPTION
- check if timeParse.minutes < 10
- if so, add a leading zero to the 'minutes' string
- this is displayed beneath the medication name when a user has checked the medication off the list